### PR TITLE
Add Tor onion service to the landing page

### DIFF
--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -11,6 +11,7 @@ interface IChatState {
     connection: Peer.DataConnection|null;
     showLink: boolean;
     wasCopied: boolean;
+    wasOnionCopied: boolean;
     fileTransfers: Map<string, FileTransfer>;
 }
 
@@ -48,6 +49,8 @@ export default class Chat extends React.Component<{}, IChatState> {
         ]
     };
 
+    private readonly onionAddress = "http://xady4v2muvyix5f4k3pu3tdkkti7a7qanqpoyxbgyflfp6jk7aocgqqd.onion";
+
     private fileInputRef = React.createRef<HTMLInputElement>();
     private readonly CHUNK_SIZE = 16384; // 16KB chunks
 
@@ -58,6 +61,7 @@ export default class Chat extends React.Component<{}, IChatState> {
             connection: null,
             showLink: false,
             wasCopied: false,
+            wasOnionCopied: false,
             fileTransfers: new Map(),
         };
     }
@@ -73,7 +77,9 @@ export default class Chat extends React.Component<{}, IChatState> {
     }
 
     public render() {
-        const link = "https://otr.to/#" + this.peerId;
+        const isOnionHost = window.location.hostname.endsWith(".onion");
+        const link = (isOnionHost ? window.location.origin : "https://otr.to") + "/#" + this.peerId;
+        const onionLink = this.onionAddress;
         const messageInput = this.state.connection ? (
             <div className="container" style={{ position: 'fixed', bottom: 0, right: '50%', transform: 'translateX(50%)', width: '100%', padding: '.5rem' }}>
                 <form onSubmit={this.sendMessage}>
@@ -230,6 +236,37 @@ export default class Chat extends React.Component<{}, IChatState> {
                         </div>
 
                         <hr/>
+
+                        {!isOnionHost && (<>
+                        <h2 className="subtitle is-4">Also available via Tor</h2>
+                        <p style={{marginBottom: "1rem"}}>For even more privacy you can reach otr.to as a Tor onion
+                            service. Open the following address in the <a href="https://www.torproject.org/download/"
+                            target="_blank" rel="noopener noreferrer">Tor Browser</a>:</p>
+
+                        <div className="columns is-gapless is-mobile" style={{marginBottom: "1.5rem"}}>
+                            <div className="column">
+                                <input className="input" value={onionLink} readOnly={true}
+                                       style={{borderRadius: '4px 0 0 4px', fontFamily: 'monospace'}}/>
+                            </div>
+                            <div className="column is-narrow">
+                                <CopyToClipboard text={onionLink}
+                                                 onCopy={() => this.setState({wasOnionCopied: true})}>
+                                    {this.state.wasOnionCopied ? (
+                                        <button className="button is-primary has-text-weight-bold"
+                                                style={{borderRadius: '0 4px 4px 0'}}>
+                                            <span>Copied!</span>
+                                        </button>
+                                    ) : (
+                                        <button className="button is-primary" style={{borderRadius: '0 4px 4px 0'}}>
+                                            <span className="icon is-marginless"><img src="/images/icons/copy.svg"
+                                                                                      alt="Copy onion address"/></span>
+                                            <span className="is-hidden">Copy onion address</span>
+                                        </button>
+                                    )}
+                                </CopyToClipboard>
+                            </div>
+                        </div>
+                        </>)}
 
                         <a className="github-button" href="https://github.com/jermainee/otr.to" data-size="large"
                            data-show-count="true" aria-label="Star jermainee/nachricht.co on GitHub">Star</a>


### PR DESCRIPTION
otr.to is now reachable as a Tor onion service. This surfaces the onion address on the landing page and makes shared chat links stay on whichever network the visitor is already using.

## What changed

**Tor section above the GitHub button** — a short "Also available via Tor" block with a link to the Tor Browser download and the onion address in a read-only field with a copy button, styled like the existing chat link field.

**Network-aware chat link** ([src/Chat.tsx:80](https://github.com/jermainee/otr.to/blob/tor-onion-service/src/Chat.tsx#L80)):

```ts
const isOnionHost = window.location.hostname.endsWith(".onion");
const link = (isOnionHost ? window.location.origin : "https://otr.to") + "/#" + this.peerId;
```

On otr.to the link stays `https://otr.to/#…`; served from the onion domain it becomes `http://xady…qqd.onion/#…`. The Telegram / WhatsApp / e-mail share buttons pick this up automatically since they reuse the same `link`.

## For the reviewer

- The Tor section is hidden when the visitor is already on the onion domain (`{!isOnionHost && …}`) — the hint would be redundant there. Easy to make unconditional if you'd rather always show it.
- `tsc` and `webpack --mode=production` pass. The clearnet rendering was verified against a local build (both fields show the expected values); the onion branch depends on the hostname and could not be exercised locally.
- `public/dist/` is gitignored, so no bundle is included — the deployment builds itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)