### PR TITLE
Show the onion address as a plain link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 public/dist/
 .idea/
 *.DS_Store
+coverage/

--- a/src/Chat.tsx
+++ b/src/Chat.tsx
@@ -11,7 +11,6 @@ interface IChatState {
     connection: Peer.DataConnection|null;
     showLink: boolean;
     wasCopied: boolean;
-    wasOnionCopied: boolean;
     fileTransfers: Map<string, FileTransfer>;
 }
 
@@ -61,7 +60,6 @@ export default class Chat extends React.Component<{}, IChatState> {
             connection: null,
             showLink: false,
             wasCopied: false,
-            wasOnionCopied: false,
             fileTransfers: new Map(),
         };
     }
@@ -239,33 +237,13 @@ export default class Chat extends React.Component<{}, IChatState> {
 
                         {!isOnionHost && (<>
                         <h2 className="subtitle is-4">Also available via Tor</h2>
-                        <p style={{marginBottom: "1rem"}}>For even more privacy you can reach otr.to as a Tor onion
-                            service. Open the following address in the <a href="https://www.torproject.org/download/"
-                            target="_blank" rel="noopener noreferrer">Tor Browser</a>:</p>
+                        <p>For even more privacy you can reach otr.to as a Tor onion service. Open the following
+                            address in the <a href="https://www.torproject.org/download/" target="_blank"
+                            rel="noopener noreferrer">Tor Browser</a>:</p>
 
-                        <div className="columns is-gapless is-mobile" style={{marginBottom: "1.5rem"}}>
-                            <div className="column">
-                                <input className="input" value={onionLink} readOnly={true}
-                                       style={{borderRadius: '4px 0 0 4px', fontFamily: 'monospace'}}/>
-                            </div>
-                            <div className="column is-narrow">
-                                <CopyToClipboard text={onionLink}
-                                                 onCopy={() => this.setState({wasOnionCopied: true})}>
-                                    {this.state.wasOnionCopied ? (
-                                        <button className="button is-primary has-text-weight-bold"
-                                                style={{borderRadius: '0 4px 4px 0'}}>
-                                            <span>Copied!</span>
-                                        </button>
-                                    ) : (
-                                        <button className="button is-primary" style={{borderRadius: '0 4px 4px 0'}}>
-                                            <span className="icon is-marginless"><img src="/images/icons/copy.svg"
-                                                                                      alt="Copy onion address"/></span>
-                                            <span className="is-hidden">Copy onion address</span>
-                                        </button>
-                                    )}
-                                </CopyToClipboard>
-                            </div>
-                        </div>
+                        <p><a href={onionLink} style={{wordBreak: 'break-all'}}>{onionLink}</a></p>
+
+                        <hr/>
                         </>)}
 
                         <a className="github-button" href="https://github.com/jermainee/otr.to" data-size="large"

--- a/src/__tests__/Chat.clearnet.test.tsx
+++ b/src/__tests__/Chat.clearnet.test.tsx
@@ -51,22 +51,19 @@ describe('Chat on the clearnet domain', () => {
         expect(screen.getAllByText('Copied!')).toHaveLength(1);
     });
 
-    it('advertises the onion service', () => {
+    it('advertises the onion service as a plain link', () => {
         render(<Chat/>);
 
         expect(screen.getByText('Also available via Tor')).toBeInTheDocument();
-        expect(screen.getByDisplayValue(ONION_ADDRESS)).toBeInTheDocument();
+        expect(screen.getByRole('link', {name: ONION_ADDRESS})).toHaveAttribute('href', ONION_ADDRESS);
         expect(screen.getByText('Tor Browser')).toHaveAttribute(
             'href', 'https://www.torproject.org/download/');
     });
 
-    it('copies the onion address, not the chat link', () => {
-        render(<Chat/>);
+    it('separates the Tor section from the GitHub button', () => {
+        const {container} = render(<Chat/>);
 
-        fireEvent.click(screen.getByAltText('Copy onion address'));
-
-        expect(copy).toHaveBeenCalledTimes(1);
-        expect(copy.mock.calls[0][0]).toBe(ONION_ADDRESS);
-        expect(screen.getAllByText('Copied!')).toHaveLength(1);
+        expect(container.querySelectorAll('hr')).toHaveLength(2);
+        expect(screen.getByLabelText(/Star .* on GitHub/).previousElementSibling.tagName).toBe('HR');
     });
 });

--- a/src/__tests__/Chat.fileTransfer.test.tsx
+++ b/src/__tests__/Chat.fileTransfer.test.tsx
@@ -210,5 +210,8 @@ describe('Sending a file', () => {
         await send(new File(['x'], 'notes.txt', {type: 'text/plain'}));
 
         expect(fileInput().value).toBe('');
+
+        // The chunks are read asynchronously; let them finish before unmounting.
+        await waitFor(() => expect(screen.getByText('✅ File sent: notes.txt')).toBeInTheDocument());
     });
 });

--- a/src/__tests__/Chat.onion.test.tsx
+++ b/src/__tests__/Chat.onion.test.tsx
@@ -36,10 +36,12 @@ describe('Chat served from the onion service', () => {
     });
 
     it('does not advertise the onion service to visitors already on it', () => {
-        render(<Chat/>);
+        const {container} = render(<Chat/>);
 
         expect(screen.queryByText('Also available via Tor')).not.toBeInTheDocument();
-        expect(screen.queryByAltText('Copy onion address')).not.toBeInTheDocument();
+        expect(screen.queryByRole('link', {name: ONION_ORIGIN})).not.toBeInTheDocument();
+        // Only the rule that already sat above the GitHub button.
+        expect(container.querySelectorAll('hr')).toHaveLength(1);
     });
 
     it('connects to the peer id from an onion link that was opened', () => {


### PR DESCRIPTION
## What changed

**The onion address is now a plain link** instead of a read-only input with a copy button. It was a lot of chrome for something you read once and open — and in the Tor Browser it can simply be clicked.

```diff
-<div className="columns is-gapless is-mobile">
-    <input className="input" value={onionLink} readOnly={true} .../>
-    <CopyToClipboard text={onionLink} ...>...</CopyToClipboard>
-</div>
+<p><a href={onionLink} style={{wordBreak: 'break-all'}}>{onionLink}</a></p>
```

`wordBreak: 'break-all'` keeps the 56-character address from overflowing on narrow screens. The copy button was the only user of the `wasOnionCopied` state, so that goes too.

**An `<hr/>` above the GitHub button.** It sits at the end of the Tor section rather than unconditionally before the button, so there is exactly one rule there in both cases: on the onion host the Tor section is hidden and the rule that already preceded it does the job, instead of two rules stacking up.

## Also in here

`.gitignore` — the coverage fix in #18 removed `coverage/` from the index but left the `.gitignore` edit unstaged, so the rule never actually landed on master. Without it the next `git add -A` re-commits the generated report (and with it the CodeQL alert). One line, fixed here.

## For the reviewer

- Tests follow the markup: the copy-button test is replaced by one asserting the link and its `href`, the onion-host test now checks the link is absent and that only one rule remains. Still 47 tests, 100% of the lines in `src/`.
- One test now waits for the file send it starts. It was finishing early and leaving `saveMessage` to `setState` after unmount, which printed a React warning into the CI log.
- Verified in a real production build, not just jsdom: one onion link with the address as its text, the onion input gone, two rules on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)